### PR TITLE
SAGE-792: set the hostname (sysname-nodeid) only after registration

### DIFF
--- a/ROOTFS/etc/systemd/system/waggle-node-hostname.service
+++ b/ROOTFS/etc/systemd/system/waggle-node-hostname.service
@@ -1,16 +1,13 @@
 [Unit]
 Description=Waggle Hostname Service
-After=waggle-nodeid.service
-Before=k3s.service
-Wants=waggle-nodeid.service
+Before=network-pre.target
+Wants=network-pre.target
+ConditionPathExists=/etc/waggle/node-id
 
 [Service]
 ExecStart=/usr/bin/waggle_node_hostname.py -n /etc/waggle/node-id
 Type=oneshot
 RemainAfterExit=yes
-Restart=on-failure
-RestartSec=30
 
 [Install]
 WantedBy=default.target
-WantedBy=k3s.service

--- a/ROOTFS/usr/bin/waggle_node_hostname.py
+++ b/ROOTFS/usr/bin/waggle_node_hostname.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
 import click
+import configparser
 import logging
-import uuid
 import socket
+import sys
+import uuid
 from pathlib import Path
 
 software_version = "{{VERSION}}"
@@ -11,43 +13,79 @@ software_version = "{{VERSION}}"
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 def_nodeid = "/etc/waggle/node-id"
+config_file = "/etc/waggle/config.ini"
 
 
-def set_hostname(nodeid=None):
-    """Set the hostname using the node ID string
+def set_hostname(sysname=None, nodeid=None):
+    """Set the system hostname to '<sysname>-<nodeid>'
 
     Arguments:
-        node ID (str): the node ID string to generate the hostname from
+        sysname (str): the system name to prepend to the hostname
+        nodeid (str): the Node ID name to postpend to the hostname
 
     Returns:
         none, exception on error
     """
-    logging.info(f"Set the system hostname [node ID: {nodeid}]")
+    logging.info(f"Set the system hostname [sysname: {sysname} | nodeid: {nodeid}]")
+
+    if not sysname:
+        raise Exception("Unable to set hostname, `sysname` must not be empty")
+    if not isinstance(sysname, str):
+        raise TypeError(
+            f"Unable to set hostname, `sysname` [{sysname}] must be a string"
+        )
 
     if not nodeid:
-        raise Exception("Unable to set hostname, node ID must not be empty")
+        raise Exception("Unable to set hostname, `nodeid` must not be empty")
     if not isinstance(nodeid, str):
-        raise TypeError(f"Unable to set hostname, node ID [{nodeid}] must be a string")
+        raise TypeError(f"Unable to set hostname, `nodeid` [{nodeid}] must be a string")
+
+    hostname = f"{sysname}-{nodeid}"
 
     # set the hostname for this and future boots
     try:
-        socket.sethostname(nodeid)
-        logging.info(f"Successfuly set the run-time hostname [{nodeid}]")
+        socket.sethostname(hostname)
+        logging.info(f"Successfuly set the run-time hostname [{hostname}]")
     except:
-        logging.warning(f"Unable to set the run-time hostname [{nodeid}]")
+        logging.warning(f"Unable to set the run-time hostname [{hostname}]")
         pass
     with open("/etc/hostname", "w") as file:
-        file.write(nodeid)
+        file.write(hostname)
 
 
 @click.command()
-@click.version_option(version=software_version, message=f'version: %(version)s')
+@click.version_option(version=software_version, message=f"version: %(version)s")
 @click.option(
     "-n", "--nodeid", "nodeid_file", default=def_nodeid, help="node ID file to use"
 )
 def main(nodeid_file):
-
     logging.info(f"Waggle set hostname [node ID file: {nodeid_file}]")
+
+    config = configparser.ConfigParser()
+    try:
+        config.read(config_file)
+    except:
+        logging.error(f"config error: unable to read config file {config_file}")
+        sys.exit(1)
+
+    # only proceed with setting a custom hostname after registration is complete
+    try:
+        regkey = str(config["reverse-tunnel"]["key"])
+    except:
+        logging.error(f"config error: unable to load 'reverse-tunnel[key]'")
+        sys.exit(1)
+    if not Path(f"{regkey}").exists():
+        logging.warning(f"Registration key [{regkey}] missing, will NOT set hostname")
+        sys.exit(0)
+
+    # the registration key exists, so set the hostname
+    try:
+        sysname = config["system"]["name"]
+    except:
+        sysname = "unknown"
+        logging.warning(
+            f"System name config entry 'system[name]' not found, using default '{sysname}'"
+        )
 
     nodeid = None
     try:
@@ -55,8 +93,9 @@ def main(nodeid_file):
             nodeid = f.readline().strip()
     except Exception as e:
         logging.error(f"Unable to read node ID from file [{nodeid_file}]")
+        sys.exit(1)
 
-    set_hostname(nodeid)
+    set_hostname(sysname, nodeid)
 
 
 if __name__ == "__main__":

--- a/tests/bk_key.pem.default
+++ b/tests/bk_key.pem.default
@@ -1,0 +1,1 @@
+# fake registration key

--- a/tests/config.ini.badformat
+++ b/tests/config.ini.badformat
@@ -1,0 +1,1 @@
+badformat

--- a/tests/config.ini.badrevtun1
+++ b/tests/config.ini.badrevtun1
@@ -1,0 +1,5 @@
+[system]
+name = ws-nxcore
+
+[reverse-tunnel-missing]
+key = /etc/waggle/bk_key.pem

--- a/tests/config.ini.badrevtun2
+++ b/tests/config.ini.badrevtun2
@@ -1,0 +1,5 @@
+[system]
+name = ws-nxcore
+
+[reverse-tunnel]
+key-missing = /etc/waggle/bk_key.pem

--- a/tests/config.ini.badsysname
+++ b/tests/config.ini.badsysname
@@ -1,0 +1,5 @@
+[system-bad]
+name = ws-nxcore
+
+[reverse-tunnel]
+key = /etc/waggle/bk_key.pem

--- a/tests/config.ini.default
+++ b/tests/config.ini.default
@@ -1,0 +1,5 @@
+[system]
+name = ws-nxcore
+
+[reverse-tunnel]
+key = /etc/waggle/bk_key.pem

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,11 +8,26 @@ from ROOTFS.usr.bin.waggle_node_hostname import main
 from pathlib import Path
 
 
-def test_default_nodeid():
-    """Test default (from disk) nodeid work"""
+@pytest.fixture()
+def helper():
+    print("****SETUP*****")
+    # load default files
     Path("/etc/waggle").mkdir(parents=True, exist_ok=True)
     shutil.copy("/workdir/tests/node-id.default", "/etc/waggle/node-id")
+    shutil.copy("/workdir/tests/config.ini.default", "/etc/waggle/config.ini")
+    shutil.copy("/workdir/tests/bk_key.pem.default", "/etc/waggle/bk_key.pem")
+    # seed the hostname with a test value
+    with open("/etc/hostname", "w") as fp:
+        fp.write("pre-test-hostname")
 
+    yield
+
+    print("****TEARDOWN*****")
+    shutil.rmtree("/etc/waggle")
+
+
+def test_default_nodeid_sysname(helper):
+    """Test default (from disk) nodeid and sysname (from config) works"""
     runner = CliRunner()
     result = runner.invoke(main)
     assert result.exit_code == 0
@@ -20,18 +35,15 @@ def test_default_nodeid():
     # assert the /etc/hostname file exists
     assert Path("/etc/hostname").exists()
 
-    # assert it is 16 characters long
+    # assert hostname is correct
     with open("/etc/hostname", "r") as file:
         content = file.readline()
-    assert len(content) == 16
-    assert content == "0000ABCDEF123456"
-
-    # clean-up the default node-id file for future tests
-    os.remove("/etc/waggle/node-id")
+    assert len(content) == 26
+    assert content == "ws-nxcore-0000ABCDEF123456"
 
 
-def test_input_nodeid():
-    """Test provided nodeid works"""
+def test_input_nodeid(helper):
+    """Test provided nodeid and default sysname (from config) works"""
     runner = CliRunner()
     result = runner.invoke(main, ["-n", "/workdir/tests/node-id.input"])
     assert result.exit_code == 0
@@ -39,18 +51,15 @@ def test_input_nodeid():
     # assert the /etc/hostname file exists
     assert Path("/etc/hostname").exists()
 
-    # assert it is 16 characters long and matches test file
+    # assert hostname is correct
     with open("/etc/hostname", "r") as file:
         content = file.readline()
-    assert len(content) == 16
-    assert content == "0000123456789ABC"
+    assert len(content) == 26
+    assert content == "ws-nxcore-0000123456789ABC"
 
 
-def test_empty_nodeid():
-    """Test that a bad node-id file results in execution failure"""
-    # seed the hostname with a test value
-    with open("/etc/hostname", "w") as fp:
-        fp.write("emptynodeid")
+def test_empty_nodeid(helper):
+    """Test that an empty node-id file results in hostname failure"""
     # create empty node file
     with open("/tmp/node-id.empty", "w") as fp:
         pass
@@ -65,15 +74,11 @@ def test_empty_nodeid():
     # assert matches the before test value
     with open("/etc/hostname", "r") as file:
         content = file.readline()
-    assert content == "emptynodeid"
+    assert content == "pre-test-hostname"
 
 
-def test_missing_nodeid():
+def test_missing_nodeid(helper):
     """Test invalid node-id file path"""
-    # seed the hostname with a test value
-    with open("/etc/hostname", "w") as fp:
-        fp.write("missingnodeid")
-
     runner = CliRunner()
     result = runner.invoke(main, ["-n", "/tmp/node-id.missing"])
     assert result.exit_code != 0
@@ -84,4 +89,92 @@ def test_missing_nodeid():
     # assert matches the before test value
     with open("/etc/hostname", "r") as file:
         content = file.readline()
-    assert content == "missingnodeid"
+    assert content == "pre-test-hostname"
+
+
+def test_badformat_config(helper):
+    """Test bad formatted config.ini"""
+    shutil.copy("/workdir/tests/config.ini.badformat", "/etc/waggle/config.ini")
+
+    runner = CliRunner()
+    result = runner.invoke(main)
+    assert result.exit_code != 0
+
+    # assert the /etc/hostname file exists
+    assert Path("/etc/hostname").exists()
+
+    # assert matches the before test value
+    with open("/etc/hostname", "r") as file:
+        content = file.readline()
+    assert content == "pre-test-hostname"
+
+
+def test_missing_revtunnel_section(helper):
+    """Test for missing reverse-tunnel section in config.ini"""
+    shutil.copy("/workdir/tests/config.ini.badrevtun1", "/etc/waggle/config.ini")
+
+    runner = CliRunner()
+    result = runner.invoke(main)
+    assert result.exit_code != 0
+
+    # assert the /etc/hostname file exists
+    assert Path("/etc/hostname").exists()
+
+    # assert matches the before test value
+    with open("/etc/hostname", "r") as file:
+        content = file.readline()
+    assert content == "pre-test-hostname"
+
+
+def test_missing_revtunnel_key(helper):
+    """Test for missing reverse-tunnel[key] key in config.ini"""
+    shutil.copy("/workdir/tests/config.ini.badrevtun2", "/etc/waggle/config.ini")
+
+    runner = CliRunner()
+    result = runner.invoke(main)
+    assert result.exit_code != 0
+
+    # assert the /etc/hostname file exists
+    assert Path("/etc/hostname").exists()
+
+    # assert matches the before test value
+    with open("/etc/hostname", "r") as file:
+        content = file.readline()
+    assert content == "pre-test-hostname"
+
+
+def test_revtun_key_file_missing(helper):
+    """Test for missing reverse-tunnel key file"""
+    os.remove("/etc/waggle/bk_key.pem")
+
+    # test returns non-failure, but does not make any changes to the hostname
+    runner = CliRunner()
+    result = runner.invoke(main)
+    assert result.exit_code == 0
+
+    # assert the /etc/hostname file exists
+    assert Path("/etc/hostname").exists()
+
+    # assert matches the before test value
+    with open("/etc/hostname", "r") as file:
+        content = file.readline()
+    assert content == "pre-test-hostname"
+
+
+def test_missing_sysname_unknown(helper):
+    """Test for missing or bad system["name"] key in config.ini"""
+    shutil.copy("/workdir/tests/config.ini.badsysname", "/etc/waggle/config.ini")
+
+    # test returns non-failure, and sets a "unknown" hostname
+    runner = CliRunner()
+    result = runner.invoke(main)
+    assert result.exit_code == 0
+
+    # assert the /etc/hostname file exists
+    assert Path("/etc/hostname").exists()
+
+    # assert hostname is correct
+    with open("/etc/hostname", "r") as file:
+        content = file.readline()
+    assert len(content) == 24
+    assert content == "unknown-0000ABCDEF123456"


### PR DESCRIPTION
- start before network-pre.target to ensure hostname is set before DHCP request
- only run if the /etc/waggle/node-id file exists
- only run once per boot
- remove dependency on k3s and node-id service (node-id runs after network)
- construct hostname as <system name>-<node ID>