### PR TITLE
SAGE-792: convert to shutdown service and add `--defer` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Waggle Node Hostname Service
 
-An early boot service that sets the Debian OS hostname to the unique Node ID
-found in the `/etc/waggle/node-id` file. If the file is not found the service
-fails and exists with an error.
+An shutdown service that sets the Debian OS hostname to the system name
+(gathered from config, `/etc/waggle/config.ini`) combined with the unique
+Node ID found in the `/etc/waggle/node-id` file.
+
+```
+<system name>-<node ID>
+```
+
+To be executed on system shutdown to ensure the hostname is correct for
+the next boot.
 
 ## Build Instructions
 

--- a/ROOTFS/etc/systemd/system/waggle-node-hostname.service
+++ b/ROOTFS/etc/systemd/system/waggle-node-hostname.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Waggle Hostname Service
-Before=network-pre.target
-Wants=network-pre.target
+DefaultDependencies=no
+Before=shutdown.target
 ConditionPathExists=/etc/waggle/node-id
 
 [Service]
-ExecStart=/usr/bin/waggle_node_hostname.py -n /etc/waggle/node-id
+ExecStart=/usr/bin/waggle_node_hostname.py -n /etc/waggle/node-id --defer
 Type=oneshot
-RemainAfterExit=yes
+TimeoutStartSec=30
 
 [Install]
-WantedBy=default.target
+WantedBy=shutdown.target

--- a/create_deb.sh
+++ b/create_deb.sh
@@ -18,6 +18,7 @@ EOF
 
 # add control files
 cp -p deb/install/postinst ${BASEDIR}/DEBIAN/
+cp -p deb/install/prerm ${BASEDIR}/DEBIAN/
 
 # add core files
 cp -r ROOTFS/etc ${BASEDIR}/

--- a/deb/install/postinst
+++ b/deb/install/postinst
@@ -2,7 +2,7 @@
 
 case "${1}" in
   configure)
-    # enable the service to run on on boot
+    # enable the service to run on system shutdown
     systemctl enable waggle-node-hostname.service
   ;;
 esac

--- a/deb/install/prerm
+++ b/deb/install/prerm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+systemctl disable waggle-node-hostname.service

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,6 +42,22 @@ def test_default_nodeid_sysname(helper):
     assert content == "ws-nxcore-0000ABCDEF123456"
 
 
+def test_default_nodeid_sysname_defer(helper):
+    """Test default (from disk) nodeid and sysname (from config) works w/ defer"""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--defer"])
+    assert result.exit_code == 0
+
+    # assert the /etc/hostname file exists
+    assert Path("/etc/hostname").exists()
+
+    # assert hostname is correct
+    with open("/etc/hostname", "r") as file:
+        content = file.readline()
+    assert len(content) == 26
+    assert content == "ws-nxcore-0000ABCDEF123456"
+
+
 def test_input_nodeid(helper):
     """Test provided nodeid and default sysname (from config) works"""
     runner = CliRunner()


### PR DESCRIPTION
Added `--defer` option signals to only set the hostname in the
`/etc/hostname` file and to NOT change the current running hostname.
Therefore, on system shutdown the service is executed to prepare
the system with the correct hostname on the following boot. This ensures
that all systems services (i.e. NetworkManager, etc.) have the correct
hostname on boot.